### PR TITLE
Disable user info collection if the `client_secrets` don't contain the URL

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+UNRELEASED
+==========
+
+Fixed
+-----
+
+- Don't crash if the ``client_secrets`` don't contain a ``userinfo_uri`` key.
+
+
 2.0.0 (2023-08-21)
 ==================
 

--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -133,7 +133,17 @@ class OpenIDConnect:
         app.config.setdefault(
             "OIDC_CLIENT_SECRET", self.client_secrets["client_secret"]
         )
-        app.config.setdefault("OIDC_USERINFO_URL", self.client_secrets["userinfo_uri"])
+        try:
+            app.config.setdefault(
+                "OIDC_USERINFO_URL", self.client_secrets["userinfo_uri"]
+            )
+        except KeyError:
+            if app.config.get("OIDC_USER_INFO_ENABLED", False):
+                logger.warning(
+                    'No "userinfo_uri" entry was found in the client_secrets, '
+                    "retrieving user information is disabled."
+                )
+            app.config["OIDC_USER_INFO_ENABLED"] = False
         app.config.setdefault("OIDC_USER_INFO_ENABLED", True)
         app.config.setdefault("OIDC_INTROSPECTION_AUTH_METHOD", "client_secret_post")
         app.config.setdefault("OIDC_CLOCK_SKEW", 60)

--- a/tests/test_flask_oidc.py
+++ b/tests/test_flask_oidc.py
@@ -308,3 +308,27 @@ def test_resource_server_only(client_secrets_path):
             resp = client.get(url)
             assert resp.status_code == 404
         check_token_expiry.assert_not_called()
+
+
+def test_no_userinfo_url(client_secrets, caplog):
+    app = flask.Flask("dummy")
+    client_secrets = client_secrets.copy()
+    del client_secrets["userinfo_uri"]
+    app.config["OIDC_CLIENT_SECRETS"] = {"web": client_secrets}
+    OpenIDConnect(app)
+    assert app.config["OIDC_USER_INFO_ENABLED"] is False
+    assert len(caplog.messages) == 0
+
+
+def test_no_userinfo_url_when_enabled(client_secrets, caplog):
+    app = flask.Flask("dummy")
+    client_secrets = client_secrets.copy()
+    del client_secrets["userinfo_uri"]
+    app.config["OIDC_USER_INFO_ENABLED"] = True
+    app.config["OIDC_CLIENT_SECRETS"] = {"web": client_secrets}
+    OpenIDConnect(app)
+    assert app.config["OIDC_USER_INFO_ENABLED"] is False
+    assert caplog.messages == [
+        'No "userinfo_uri" entry was found in the client_secrets, retrieving user '
+        "information is disabled."
+    ]


### PR DESCRIPTION
Fixes: https://github.com/puiterwijk/flask-oidc/issues/160