### PR TITLE
Fix some issues raised by #21

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,15 @@ Fixed
 - Use the ``OIDC_CALLBACK_ROUTE`` with the ID provider when it is defined,
   instead of the default (:issue:`21`)
 
+Changed
+-------
+
+- The ``redirect_uri`` that is generated and sent to the ID provider is always
+  HTTPS, as `the OIDC spec`_ mandates.
+
+.. _the OIDC spec: https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+
+
 
 2.0.2 (2023-08-23)
 ==================

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,8 @@ Changed
 
 - The ``redirect_uri`` that is generated and sent to the ID provider is always
   HTTPS, as `the OIDC spec`_ mandates.
+- Don't request the ``profile`` scope by default, as version 1.x used to do
+  (:issue:`21`).
 
 .. _the OIDC spec: https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -10,6 +10,12 @@ Added
 
 - Auto-renew tokens when they have expired (if possible) (:issue:`19`)
 
+Fixed
+-----
+
+- Use the ``OIDC_CALLBACK_ROUTE`` with the ID provider when it is defined,
+  instead of the default (:issue:`21`)
+
 
 2.0.2 (2023-08-23)
 ==================

--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -133,7 +133,7 @@ class OpenIDConnect:
         app.config.setdefault("OIDC_RESOURCE_SERVER_ONLY", False)
         app.config.setdefault("OIDC_CALLBACK_ROUTE", None)
 
-        app.config.setdefault("OIDC_SCOPES", "openid profile email")
+        app.config.setdefault("OIDC_SCOPES", "openid email")
         if "openid" not in app.config["OIDC_SCOPES"]:
             raise ValueError('The value "openid" must be in the OIDC_SCOPES')
         if isinstance(app.config["OIDC_SCOPES"], (list, tuple)):

--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -131,7 +131,7 @@ class OpenIDConnect:
         app.config.setdefault("OIDC_INTROSPECTION_AUTH_METHOD", "client_secret_post")
         app.config.setdefault("OIDC_CLOCK_SKEW", 60)
         app.config.setdefault("OIDC_RESOURCE_SERVER_ONLY", False)
-        app.config.setdefault("OIDC_CALLBACK_ROUTE", "/oidc_callback")
+        app.config.setdefault("OIDC_CALLBACK_ROUTE", None)
 
         app.config.setdefault("OIDC_SCOPES", "openid profile email")
         if "openid" not in app.config["OIDC_SCOPES"]:
@@ -165,7 +165,10 @@ class OpenIDConnect:
 
         if not app.config["OIDC_RESOURCE_SERVER_ONLY"]:
             app.register_blueprint(auth_routes, url_prefix=prefix)
-            app.route(app.config["OIDC_CALLBACK_ROUTE"])(legacy_oidc_callback)
+            app.route("/oidc_callback")(legacy_oidc_callback)
+            if app.config["OIDC_CALLBACK_ROUTE"]:
+                app.route(app.config["OIDC_CALLBACK_ROUTE"])(legacy_oidc_callback)
+
         app.before_request(self._before_request)
 
     def load_secrets(self, app):

--- a/flask_oidc/views.py
+++ b/flask_oidc/views.py
@@ -52,7 +52,7 @@ def login_view():
             f"https://{request.host}{current_app.config['OIDC_CALLBACK_ROUTE']}"
         )
     else:
-        redirect_uri = url_for("oidc_auth.authorize", _external=True)
+        redirect_uri = url_for("oidc_auth.authorize", _external=True, _scheme="https")
     session["next"] = request.args.get("next", request.root_url)
     return g._oidc_auth.authorize_redirect(redirect_uri)
 

--- a/flask_oidc/views.py
+++ b/flask_oidc/views.py
@@ -47,7 +47,12 @@ auth_routes = Blueprint("oidc_auth", __name__)
 
 @auth_routes.route("/login", endpoint="login")
 def login_view():
-    redirect_uri = url_for("oidc_auth.authorize", _external=True)
+    if current_app.config["OIDC_CALLBACK_ROUTE"]:
+        redirect_uri = (
+            f"https://{request.host}{current_app.config['OIDC_CALLBACK_ROUTE']}"
+        )
+    else:
+        redirect_uri = url_for("oidc_auth.authorize", _external=True)
     session["next"] = request.args.get("next", request.root_url)
     return g._oidc_auth.authorize_redirect(redirect_uri)
 

--- a/tests/test_flask_oidc.py
+++ b/tests/test_flask_oidc.py
@@ -103,7 +103,7 @@ def test_expired_token(client, dummy_token, mocked_responses):
     assert body == {
         "grant_type": ["refresh_token"],
         "refresh_token": ["dummy_refresh_token"],
-        "scope": ["openid profile email"],
+        "scope": ["openid email"],
         "client_id": ["MyClient"],
         "client_secret": ["MySecret"],
     }

--- a/tests/test_flask_oidc.py
+++ b/tests/test_flask_oidc.py
@@ -349,3 +349,16 @@ def test_resource_server_only(client_secrets_path):
             resp = client.get(url)
             assert resp.status_code == 404
         check_token_expiry.assert_not_called()
+
+
+def test_oidc_callback_route(make_test_app):
+    with pytest.warns():
+        app = make_test_app({"OIDC_CALLBACK_ROUTE": "/dummy_cb"})
+    client = app.test_client()
+    resp = client.get("/login")
+    assert resp.status_code == 302
+    assert "redirect_uri=https%3A%2F%2Flocalhost%2Fdummy_cb" in resp.location
+    with pytest.warns():
+        resp = client.get("/dummy_cb?dummy_arg=dummy_value")
+    assert resp.status_code == 302
+    assert resp.location == "/authorize?dummy_arg=dummy_value"

--- a/tests/test_flask_oidc.py
+++ b/tests/test_flask_oidc.py
@@ -57,7 +57,7 @@ def test_signin(test_app, client, mocked_responses, dummy_token):
     token_query = parse_qs(mocked_responses.calls[1][0].body)
     assert token_query == {
         "grant_type": ["authorization_code"],
-        "redirect_uri": ["http://localhost/authorize"],
+        "redirect_uri": ["https://localhost/authorize"],
         "code": ["mock_auth_code"],
         "client_id": ["MyClient"],
         "client_secret": ["MySecret"],


### PR DESCRIPTION
See the commits for details. The main changes are:
- Use the `OIDC_CALLBACK_ROUTE` to build the `request_uri` when defined
- Always build the `request_uri` with the `https` scheme
- Don't request the `profile` scope by default