### PR TITLE
Correct typo in example in index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,7 +62,7 @@ A very basic example client::
     def index():
         if oidc.user_loggedin:
             return 'Welcome %s' % session["oidc_auth_profile"].get('email')
-        else
+        else:
             return 'Not logged in'
 
     @app.route('/login')


### PR DESCRIPTION
Very minor update - but the example currently doesn't work when pasted.