### PR TITLE
Add support to preserve next on refresh token expiration

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -277,7 +277,8 @@ This is a list of all settings supported in the current release.
 
   OIDC_PRESERVE_NEXT_ON_ERROR
     A boolean to preserve the request arg ``next`` when logging out the user
-    from a failed refresh token check.  Defaults to ``False``
+    from a failed refresh token check.  This will only work when the ``next``
+    url is the same domain as ``request.url_root``. Defaults to ``False``
 
 
 Signals

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -275,6 +275,10 @@ This is a list of all settings supported in the current release.
     ``authorize`` view. It has to be an absolute URL (starting with
     ``https://``).
 
+  OIDC_PRESERVE_NEXT_ON_ERROR
+    A boolean to preserve the request arg ``next`` when logging out the user
+    from a failed refresh token check.  Defaults to ``False``
+
 
 Signals
 =======

--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -128,6 +128,7 @@ class OpenIDConnect:
         app.config.setdefault("OIDC_CLOCK_SKEW", 60)
         app.config.setdefault("OIDC_RESOURCE_SERVER_ONLY", False)
         app.config.setdefault("OIDC_CALLBACK_ROUTE", None)
+        app.config.setdefault("OIDC_PRESERVE_NEXT_ON_ERROR", False)
 
         if "OVERWRITE_REDIRECT_URI" in app.config:
             warnings.warn(
@@ -243,7 +244,11 @@ class OpenIDConnect:
                 self.ensure_active_token(token_obj)
             except AuthlibBaseError as e:
                 logger.info(f"Could not refresh token {token_obj!r}: {e}")
-                return redirect("{}?reason=expired".format(url_for("oidc_auth.logout")))
+                redirect_url = "{}?reason=expired".format(url_for("oidc_auth.logout"))
+                next_url = request.args.get("next", None)
+                if current_app.config["OIDC_PRESERVE_NEXT_ON_ERROR"] and next_url:
+                    redirect_url = f"{redirect_url}&next={next_url}"
+                return redirect(redirect_url)
         except Exception as e:
             logger.exception("Could not check token expiration")
             abort(500, f"{e.__class__.__name__}: {e}")

--- a/tests/test_flask_oidc.py
+++ b/tests/test_flask_oidc.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 import json
-import time
 from importlib import metadata
 from unittest import mock
 from urllib.parse import parse_qs, urlparse, urlsplit
@@ -22,7 +21,7 @@ from flask_oidc import OpenIDConnect
 
 from .app import create_app
 from .app import oidc as oidc_ext
-from .utils import set_token
+from .utils import expire_token, set_token
 
 
 def callback_url_for(response):
@@ -101,8 +100,7 @@ def test_logout_redirect_loop(make_test_app, dummy_token, mocked_responses):
         mocked_responses.post(
             "https://test/openidc/Token", json={"error": "dummy"}, status=401
         )
-        dummy_token["expires_at"] = int(time.time())
-        set_token(client, dummy_token)
+        expire_token(client, dummy_token)
 
         resp = client.get("/logout?reason=expired")
         assert resp.location == "http://localhost/subpath/"
@@ -113,9 +111,7 @@ def test_expired_token(client, dummy_token, mocked_responses):
     new_token = dummy_token.copy()
     new_token["access_token"] = "this-is-new"
     refresh_call = mocked_responses.post("https://test/openidc/Token", json=new_token)
-
-    dummy_token["expires_at"] = int(time.time())
-    set_token(client, dummy_token)
+    expire_token(client, dummy_token)
 
     resp = client.get("/")
 
@@ -141,9 +137,7 @@ def test_expired_token_cant_renew(client, dummy_token, mocked_responses):
     refresh_call = mocked_responses.post(
         "https://test/openidc/Token", json={"error": "dummy"}, status=401
     )
-
-    dummy_token["expires_at"] = int(time.time())
-    set_token(client, dummy_token)
+    expire_token(client, dummy_token)
 
     resp = client.get("/?next=https://localhost/another/app")
 
@@ -155,13 +149,12 @@ def test_expired_token_cant_renew(client, dummy_token, mocked_responses):
     assert resp.location == "http://localhost/"
     assert "oidc_auth_token" not in flask.session
 
+
 def test_expired_token_cant_renew_preserve_next(client, dummy_token, mocked_responses):
     refresh_call = mocked_responses.post(
         "https://test/openidc/Token", json={"error": "dummy"}, status=401
     )
-
-    dummy_token["expires_at"] = int(time.time())
-    set_token(client, dummy_token)
+    expire_token(client, dummy_token)
 
     client.application.config["OIDC_PRESERVE_NEXT_ON_ERROR"] = True
     resp = client.get("/?next=https://localhost/another/app")
@@ -173,10 +166,10 @@ def test_expired_token_cant_renew_preserve_next(client, dummy_token, mocked_resp
     assert resp.location == "https://localhost/another/app"
     assert "oidc_auth_token" not in flask.session
 
+
 def test_expired_token_no_refresh_token(client, dummy_token):
     del dummy_token["refresh_token"]
-    dummy_token["expires_at"] = int(time.time())
-    set_token(client, dummy_token)
+    expire_token(client, dummy_token)
 
     resp = client.get("/")
 

--- a/tests/test_flask_oidc.py
+++ b/tests/test_flask_oidc.py
@@ -145,7 +145,7 @@ def test_expired_token_cant_renew(client, dummy_token, mocked_responses):
     dummy_token["expires_at"] = int(time.time())
     set_token(client, dummy_token)
 
-    resp = client.get("/")
+    resp = client.get("/?next=https://do-not-use-next.com/openidc/Token")
 
     assert refresh_call.call_count == 1
     assert resp.status_code == 302
@@ -155,6 +155,23 @@ def test_expired_token_cant_renew(client, dummy_token, mocked_responses):
     assert resp.location == "http://localhost/"
     assert "oidc_auth_token" not in flask.session
 
+def test_expired_token_cant_renew_preserve_next(client, dummy_token, mocked_responses):
+    refresh_call = mocked_responses.post(
+        "https://test/openidc/Token", json={"error": "dummy"}, status=401
+    )
+
+    dummy_token["expires_at"] = int(time.time())
+    set_token(client, dummy_token)
+
+    client.application.config["OIDC_PRESERVE_NEXT_ON_ERROR"] = True
+    resp = client.get("/?next=https://use-next.com/openidc/Token")
+    assert refresh_call.call_count == 1
+    assert resp.status_code == 302
+    assert resp.location == "/logout?reason=expired&next=https://use-next.com/openidc/Token"
+    resp = client.get(resp.location)
+    assert resp.status_code == 302
+    assert resp.location == "https://use-next.com/openidc/Token"
+    assert "oidc_auth_token" not in flask.session
 
 def test_expired_token_no_refresh_token(client, dummy_token):
     del dummy_token["refresh_token"]

--- a/tests/test_flask_oidc.py
+++ b/tests/test_flask_oidc.py
@@ -145,7 +145,7 @@ def test_expired_token_cant_renew(client, dummy_token, mocked_responses):
     dummy_token["expires_at"] = int(time.time())
     set_token(client, dummy_token)
 
-    resp = client.get("/?next=https://do-not-use-next.com/openidc/Token")
+    resp = client.get("/?next=https://localhost/another/app")
 
     assert refresh_call.call_count == 1
     assert resp.status_code == 302
@@ -164,13 +164,13 @@ def test_expired_token_cant_renew_preserve_next(client, dummy_token, mocked_resp
     set_token(client, dummy_token)
 
     client.application.config["OIDC_PRESERVE_NEXT_ON_ERROR"] = True
-    resp = client.get("/?next=https://use-next.com/openidc/Token")
+    resp = client.get("/?next=https://localhost/another/app")
     assert refresh_call.call_count == 1
     assert resp.status_code == 302
-    assert resp.location == "/logout?reason=expired&next=https://use-next.com/openidc/Token"
+    assert resp.location == "/logout?reason=expired&next=https://localhost/another/app"
     resp = client.get(resp.location)
     assert resp.status_code == 302
-    assert resp.location == "https://use-next.com/openidc/Token"
+    assert resp.location == "https://localhost/another/app"
     assert "oidc_auth_token" not in flask.session
 
 def test_expired_token_no_refresh_token(client, dummy_token):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: BSD-2-Clause
 
+import time
+
 
 def set_token(client, token, profile=None):
     _profile = {
@@ -13,3 +15,8 @@ def set_token(client, token, profile=None):
     with client.session_transaction() as session:
         session["oidc_auth_token"] = token
         session["oidc_auth_profile"] = _profile
+
+
+def expire_token(client, token):
+    token["expires_at"] = int(time.time())
+    set_token(client, token)


### PR DESCRIPTION
Adds a new config option to preserve next on error.  When set to True, it appends that value to the logout call if present.
Closes: #201 