### PR TITLE
Add unique_id method to User

### DIFF
--- a/flask_oidc/model.py
+++ b/flask_oidc/model.py
@@ -59,3 +59,8 @@ class User:
     def groups(self):
         """The list of group names the user belongs to."""
         return self.profile.get("groups", [])
+
+    @property
+    def unique_id(self):
+        """The unique and immutable identifier on the Issuer side"""
+        return self.profile.get("sub")

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -22,9 +22,14 @@ def test_user_in_view(client, dummy_token):
     assert user.logged_in
     assert user.access_token == dummy_token["access_token"]
     assert user.refresh_token == dummy_token["refresh_token"]
-    assert user.profile == {"nickname": "dummy", "email": "dummy@example.com"}
+    assert user.profile == {
+        "nickname": "dummy",
+        "email": "dummy@example.com",
+        "sub": "8f006d91f4404980f89ec2a8a687d96a",
+    }
     assert user.name == "dummy"
     assert user.email == "dummy@example.com"
+    assert user.unique_id == "8f006d91f4404980f89ec2a8a687d96a"
 
 
 def test_user_with_groups(client, dummy_token):
@@ -39,6 +44,7 @@ def test_user_with_groups(client, dummy_token):
         "nickname": "dummy",
         "email": "dummy@example.com",
         "groups": ["dummy_group"],
+        "sub": "8f006d91f4404980f89ec2a8a687d96a",
     }
     assert user.groups == ["dummy_group"]
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,7 +4,11 @@
 
 
 def set_token(client, token, profile=None):
-    _profile = {"nickname": "dummy", "email": "dummy@example.com"}
+    _profile = {
+        "nickname": "dummy",
+        "email": "dummy@example.com",
+        "sub": "8f006d91f4404980f89ec2a8a687d96a",
+    }
     _profile.update(profile or {})
     with client.session_transaction() as session:
         session["oidc_auth_token"] = token


### PR DESCRIPTION
This give access to the 'sub' claim from the OIDC Issuer, as, per specification, that's the only one that will not change (see 5.7 of https://openid.net/specs/openid-connect-core-1_0-final.html).

Some downstream application will have to be fixed to use this instead of the nickname property as a compliant OIDC provider can change "nickname" or "email".

The "sub" claim is always returned in UserInfo response (5.3.2 of the spec).