### PR TITLE
Add config for redirecting users to request url when token refresh fails

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -280,8 +280,8 @@ This is a list of all settings supported in the current release.
     from a failed refresh token check.  This will only work when the ``next``
     url is the same domain as ``request.url_root``. Defaults to ``False``
 
-  OIDC_REQUEST_URL_ON_LOGOUT
-    A boolean to redirect the user to the request url when logging out the user
+  OIDC_ROOT_URL_ON_LOGOUT
+    A boolean to redirect the user to the root url when logging out the user
     from a failed refresh token check. This won't work if config
     ``OIDC_PRESERVE_NEXT_ON_ERROR`` is enabled and a ``next`` request arg exist.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -280,6 +280,11 @@ This is a list of all settings supported in the current release.
     from a failed refresh token check.  This will only work when the ``next``
     url is the same domain as ``request.url_root``. Defaults to ``False``
 
+  OIDC_REQUEST_URL_ON_LOGOUT
+    A boolean to redirect the user to the request url when logging out the user
+    from a failed refresh token check. This won't work if config
+    ``OIDC_PRESERVE_NEXT_ON_ERROR`` is enabled and a ``next`` request arg exist.
+
 
 Signals
 =======

--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -129,7 +129,7 @@ class OpenIDConnect:
         app.config.setdefault("OIDC_RESOURCE_SERVER_ONLY", False)
         app.config.setdefault("OIDC_CALLBACK_ROUTE", None)
         app.config.setdefault("OIDC_PRESERVE_NEXT_ON_ERROR", False)
-        app.config.setdefault("OIDC_REQUEST_URL_ON_LOGOUT", False)
+        app.config.setdefault("OIDC_ROOT_URL_ON_LOGOUT", False)
 
         if "OVERWRITE_REDIRECT_URI" in app.config:
             warnings.warn(
@@ -246,12 +246,15 @@ class OpenIDConnect:
             except AuthlibBaseError as e:
                 logger.info(f"Could not refresh token {token_obj!r}: {e}")
                 redirect_url = "{}?reason=expired".format(url_for("oidc_auth.logout"))
-                next_url = request.args.get("next", None)
-                if current_app.config["OIDC_PRESERVE_NEXT_ON_ERROR"] and next_url:
+                next_url: Optional[str] = quote_plus(request.url)
+                next_arg = request.args.get("next", None)
+                if current_app.config["OIDC_PRESERVE_NEXT_ON_ERROR"] and next_arg:
+                    next_url = next_arg
+                elif current_app.config["OIDC_ROOT_URL_ON_LOGOUT"]:
+                    # Redirect to root url after logout
+                    next_url = None
+                if next_url is not None:
                     redirect_url = f"{redirect_url}&next={next_url}"
-                elif current_app.config["OIDC_REQUEST_URL_ON_LOGOUT"]:
-                    # Redirect to request url after logout
-                    redirect_url = f"{redirect_url}&next={quote_plus(request.url)}"
                 return redirect(redirect_url)
         except Exception as e:
             logger.exception("Could not check token expiration")

--- a/flask_oidc/__init__.py
+++ b/flask_oidc/__init__.py
@@ -129,6 +129,7 @@ class OpenIDConnect:
         app.config.setdefault("OIDC_RESOURCE_SERVER_ONLY", False)
         app.config.setdefault("OIDC_CALLBACK_ROUTE", None)
         app.config.setdefault("OIDC_PRESERVE_NEXT_ON_ERROR", False)
+        app.config.setdefault("OIDC_REQUEST_URL_ON_LOGOUT", False)
 
         if "OVERWRITE_REDIRECT_URI" in app.config:
             warnings.warn(
@@ -248,6 +249,9 @@ class OpenIDConnect:
                 next_url = request.args.get("next", None)
                 if current_app.config["OIDC_PRESERVE_NEXT_ON_ERROR"] and next_url:
                     redirect_url = f"{redirect_url}&next={next_url}"
+                elif current_app.config["OIDC_REQUEST_URL_ON_LOGOUT"]:
+                    # Redirect to request url after logout
+                    redirect_url = f"{redirect_url}&next={quote_plus(request.url)}"
                 return redirect(redirect_url)
         except Exception as e:
             logger.exception("Could not check token expiration")

--- a/flask_oidc/views.py
+++ b/flask_oidc/views.py
@@ -105,6 +105,7 @@ def authorize_view() -> ResponseValue:
         del session["next"]
     except KeyError:
         return_to = request.url_root
+    flash("You were successfully logged in.")
     after_authorize.send(g._oidc_auth, token=token, return_to=return_to)
     return redirect(return_to)
 

--- a/tests/test_flask_oidc.py
+++ b/tests/test_flask_oidc.py
@@ -167,6 +167,28 @@ def test_expired_token_cant_renew_preserve_next(client, dummy_token, mocked_resp
     assert "oidc_auth_token" not in flask.session
 
 
+def test_expired_token_cant_renew_request_url(client, dummy_token, mocked_responses):
+    refresh_call = mocked_responses.post(
+        "https://test/openidc/Token", json={"error": "dummy"}, status=401
+    )
+    expire_token(client, dummy_token)
+
+    client.application.config["OIDC_REQUEST_URL_ON_LOGOUT"] = True
+
+    resp = client.get("/subpath/?key=value")
+
+    assert refresh_call.call_count == 1
+    assert resp.status_code == 302
+    assert (
+        resp.location
+        == "/logout?reason=expired&next=http%3A%2F%2Flocalhost%2Fsubpath%2F%3Fkey%3Dvalue"
+    )
+    resp = client.get(resp.location)
+    assert resp.status_code == 302
+    assert resp.location == "http://localhost/subpath/?key=value"
+    assert "oidc_auth_token" not in flask.session
+
+
 def test_expired_token_no_refresh_token(client, dummy_token):
     del dummy_token["refresh_token"]
     expire_token(client, dummy_token)

--- a/tests/test_flask_oidc.py
+++ b/tests/test_flask_oidc.py
@@ -143,10 +143,13 @@ def test_expired_token_cant_renew(client, dummy_token, mocked_responses):
 
     assert refresh_call.call_count == 1
     assert resp.status_code == 302
-    assert resp.location == "/logout?reason=expired"
+    assert (
+        resp.location
+        == "/logout?reason=expired&next=http%3A%2F%2Flocalhost%2F%3Fnext%3Dhttps%3A%2F%2Flocalhost%2Fanother%2Fapp"
+    )
     resp = client.get(resp.location)
     assert resp.status_code == 302
-    assert resp.location == "http://localhost/"
+    assert resp.location == "http://localhost/?next=https://localhost/another/app"
     assert "oidc_auth_token" not in flask.session
 
 
@@ -167,25 +170,22 @@ def test_expired_token_cant_renew_preserve_next(client, dummy_token, mocked_resp
     assert "oidc_auth_token" not in flask.session
 
 
-def test_expired_token_cant_renew_request_url(client, dummy_token, mocked_responses):
+def test_expired_token_cant_renew_root_url(client, dummy_token, mocked_responses):
     refresh_call = mocked_responses.post(
         "https://test/openidc/Token", json={"error": "dummy"}, status=401
     )
     expire_token(client, dummy_token)
 
-    client.application.config["OIDC_REQUEST_URL_ON_LOGOUT"] = True
+    client.application.config["OIDC_ROOT_URL_ON_LOGOUT"] = True
 
     resp = client.get("/subpath/?key=value")
 
     assert refresh_call.call_count == 1
     assert resp.status_code == 302
-    assert (
-        resp.location
-        == "/logout?reason=expired&next=http%3A%2F%2Flocalhost%2Fsubpath%2F%3Fkey%3Dvalue"
-    )
+    assert resp.location == "/logout?reason=expired"
     resp = client.get(resp.location)
     assert resp.status_code == 302
-    assert resp.location == "http://localhost/subpath/?key=value"
+    assert resp.location == "http://localhost/"
     assert "oidc_auth_token" not in flask.session
 
 
@@ -196,7 +196,7 @@ def test_expired_token_no_refresh_token(client, dummy_token):
     resp = client.get("/")
 
     assert resp.status_code == 302
-    assert resp.location == "/logout?reason=expired"
+    assert resp.location == "/logout?reason=expired&next=http%3A%2F%2Flocalhost%2F"
     resp = client.get(resp.location)
     assert resp.status_code == 302
     assert resp.location == "http://localhost/"


### PR DESCRIPTION
This patch adds a config `OIDC_REQUEST_URL_ON_LOGOUT` to redirecting the user to the request url instead of the request root url when the token refresh fails. For example, in keycloak the refresh fails when the client session expires.

Fix #251